### PR TITLE
Fixed createConfirmBox to allow prompt=0 (with initial_nick or url nick)

### DIFF
--- a/js/ui/panes/connect.js
+++ b/js/ui/panes/connect.js
@@ -127,9 +127,18 @@ qwebirc.ui.Panes.Connect.pclass = new Class({
     var td = new Element("td");
     tr.appendChild(td);
 
+    var form = new Element("form");
+    td.appendChild(form);
+
     var yes = new Element("input", {"type": "submit", "value": "Connect"});
-    td.appendChild(yes);
+    form.appendChild(yes);
     yes.focus();
+
+    form.addEvent("submit", function(e) {
+      new Event(e).stop();
+      this.connect(null);
+    }.bind(this));
+
   },
 
   createLoginBox: function(channel) {


### PR DESCRIPTION
The function createConfirmBox previously only created a submit button with no form element, and no events bound to the button.  This commit fixes that by adding a form element, adding the submit button to the form, and adding a simple event bound to the button.

This allows you to do ?nick=XXXX&channels=help&prompt=0 to pass in all the parameters you need to connect.
