### PR TITLE
connect.js: clarify the connect window with an abbr element about what logging into services means

### DIFF
--- a/js/ui/panes/connect.js
+++ b/js/ui/panes/connect.js
@@ -203,7 +203,10 @@ qwebirc.ui.Panes.Connect.pclass = new Class({
 
       var d1 = new Element("td");
       if(label)
-        d1.set("text", label);
+        if($type(label) == "element")
+          d1.appendChild(label)
+        else
+          d1.set("text", label);
       r.appendChild(d1);
 
       var d2 = new Element("td");
@@ -226,7 +229,18 @@ qwebirc.ui.Panes.Connect.pclass = new Class({
       var srvbutton = new Element("input");
       srvbutton.set("type", "checkbox");
       srvbutton.set("checked", false);
-      createRow("Login to Services:", srvbutton);
+      var loginLabel = new Element("div");
+      var loginText = new Element("span");
+      loginText.set("text", "Login to ");
+      loginLabel.appendChild(loginText);
+      var loginAbbr = new Element("abbr");
+      loginAbbr.set("text", "Services");
+      loginAbbr.set("title", "If you've previously registered for a services account, you may log in here.");
+      loginLabel.appendChild(loginAbbr);
+      var loginPrompt = new Element("span");
+      loginPrompt.set("text", ":");
+      loginLabel.appendChild(loginPrompt);
+      createRow(loginLabel, srvbutton);
 
       var user = new Element("input");
       var userRow = createRow("Username:", user, {})[0];


### PR DESCRIPTION
Inspired by a comment on a forum about the accessibility of IRC, it was apparent that the welcome window's "Login to Services" option could be unclear to users with little experience with IRC, and generally webchat should try to be as straightforward as possible for anyone attempting to connect, without confusing options.

This pull request adds a small `<abbr>` element to this label - `Login to Services` - which, when moused-over, gives further information about what this option actually does.

![tooltip](http://i.imgur.com/bwoFT5S.png)

To achieve this, the `createRow` function was modified to allow either an `Element` or `string` to be passed as a label, instead of just a `string`. This doesn't affect any previous uses of the function but allows us to pass labels such as this `<abbr>` one.